### PR TITLE
Refined Caller-ID regex

### DIFF
--- a/gatekeeper.py
+++ b/gatekeeper.py
@@ -216,7 +216,7 @@ class GateKeeper:
 
   def wait_for_call(self):
     self.data_channel.isOpen()
-    call_id_pattern = re.compile('.*CLIP: "(.*?)",.*')
+    call_id_pattern = re.compile('^\+CLIP:[^"]+"(\d*?)"')
     creg_pattern = re.compile('.*CREG.*0,[^1]')
     lastTime = time.time()
     while True:
@@ -258,7 +258,7 @@ class GateKeeper:
       url_log.join()
     else:
       if number == "":
-        number = "Hidden number"
+        number = "Hidden"
       log.info("Did not open the gate for "  + number + ", number is not kown.")
       # Setup thread names, need to figure out better place and way to do this, but for now This Works™
       dingdong = Thread(target=self.dingdong, args=())


### PR DESCRIPTION
Caller-ID regex pattern should now better handle CLIP-field (caller-id string with caller number and other data that modem spits out when phone rings) to have only numbers or empty string (hidden number), but nothing else (no non-numeric value)
